### PR TITLE
Route logic moved to a separate class + Ability to generate different route compilation strategies using settings[:route_class].

### DIFF
--- a/lib/hobbit.rb
+++ b/lib/hobbit.rb
@@ -1,3 +1,4 @@
 require 'hobbit/base'
 require 'hobbit/response'
+require 'hobbit/route'
 require 'hobbit/version'

--- a/lib/hobbit/route.rb
+++ b/lib/hobbit/route.rb
@@ -1,0 +1,22 @@
+module Hobbit
+  class Route
+    attr_reader :block, :compiled_path, :path
+
+    def initialize(path, &block)
+      @path, @block = path, block
+      compile
+    end
+
+    def compile
+      @compiled_path = @path.gsub(/:\w+/) do |match|
+        extra_params << match.gsub(':', '').to_sym
+        '([^/?#]+)'
+      end
+      @compiled_path = /^#{@compiled_path}$/
+    end
+
+    def extra_params
+      @extra_params ||= Array.new
+    end
+  end
+end

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -21,12 +21,12 @@ describe Hobbit::Base do
   describe "::#{verb.downcase}" do
     it 'must add a route to @routes' do
       route = app.to_app.class.routes['#{verb}'].first
-      route[:path].must_equal ''
+      route.path.must_equal ''
     end
 
     it 'must extract the extra_params' do
       route = app.to_app.class.routes['#{verb}'].last
-      route[:extra_params].must_equal [:name]
+      route.extra_params.must_equal [:name]
     end
   end
 EOS
@@ -40,6 +40,7 @@ EOS
       settings.must_be_kind_of Hash
       settings.must_include :request_class
       settings.must_include :response_class
+      settings.must_include :route_class
     end
 
     it 'must be initialized with request_class as Rack::Request' do
@@ -48,6 +49,10 @@ EOS
 
     it 'must be initialized with request_class as Hobbit::Response' do
       settings[:response_class].must_equal Hobbit::Response
+    end
+
+    it 'must be initialized with request_class as Hobbit::Route' do
+      settings[:route_class].must_equal Hobbit::Route
     end
   end
 


### PR DESCRIPTION
Hola Patricio,

The following is an approach to decouple the route compilation strategy from the base class. 
The advantages that I see are the following:
- Less code in the base class :)
- Ability to generate different route compilation strategies to make it easier to extend hobbit ( For example using https://github.com/rkh/mustermann via a plugin in contrib) . To do that, I would like to discuss the best approach to set settings[:route_class](or any other setting).

Let me know if you find these useful. This has a minor compatibility break change, but I think that it should be easy to adapt the code to make it backwards compatible.
