### PR TITLE
Change the value of 'Content-Length' to String.

### DIFF
--- a/lib/hobbit/response.rb
+++ b/lib/hobbit/response.rb
@@ -11,7 +11,7 @@ module Hobbit
     end
 
     def finish
-      headers['Content-Length'] = body.each.map(&:size).inject { |memo, current| memo += current }
+      headers['Content-Length'] = body.each.map(&:size).inject { |memo, current| memo += current }.to_s
       [status, headers, body]
     end
 

--- a/spec/base_spec.rb
+++ b/spec/base_spec.rb
@@ -233,7 +233,7 @@ EOS
 
     it 'return the response given to halt function' do
       get '/halt'
-      last_response.headers.must_equal({ 'Content-Length' => nil })
+      last_response.headers.must_equal({ 'Content-Length' => '' })
       last_response.body.must_equal ''
       last_response.status.must_equal 501
     end
@@ -258,7 +258,7 @@ EOS
 
     it 'accepts headers' do
       get '/halt_headers'
-      last_response.headers.must_equal({ header: 'OK', 'Content-Length' => nil })
+      last_response.headers.must_equal({ header: 'OK', 'Content-Length' => '' })
       last_response.status.must_equal 501
     end
   end

--- a/spec/response_spec.rb
+++ b/spec/response_spec.rb
@@ -59,7 +59,7 @@ describe Hobbit::Response do
       response = Hobbit::Response.new body, status, headers
       s, h, b = response.finish
       h.must_include 'Content-Length'
-      h['Content-Length'].must_equal body.each.map(&:size).inject { |m, s| m += s }
+      h['Content-Length'].must_equal '17'
     end
   end
 


### PR DESCRIPTION
A header value must be a String, but the value of 'Content-Length' was a Fixnum.

Without this fix, we will have a Rack::Lint::LintError 
