### PR TITLE
Don't set `Content-Length` header for HTTP 204

### DIFF
--- a/lib/hobbit/response.rb
+++ b/lib/hobbit/response.rb
@@ -21,7 +21,9 @@ module Hobbit
     end
 
     def finish
-      headers['Content-Length'] = @length.to_s
+      unless (100..199).include?(status) || status == 204
+        headers['Content-Length'] = @length.to_s
+      end
       [status, headers, body]
     end
 

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -96,6 +96,12 @@ scope Hobbit::Response do
       assert_includes h, 'Content-Length'
       assert_equal '0', h['Content-Length']
     end
+
+    test 'does not calculate the Content-Length of the body for statuses that do not allow Content-Length headers' do
+      response = Hobbit::Response.new '', 204, {}
+      s, h, b = response.finish
+      assert !h.key?('Content-Length')
+    end
   end
 
   scope '#redirect' do


### PR DESCRIPTION
According to RFC7230 (http://tools.ietf.org/html/rfc7230#section-3.3.2):

```
A server MUST NOT send a Content-Length header field in any response
   with a status code of 1xx (Informational) or 204 (No Content).
```

Hobbit is automatically generating the `Content-Length` header for all
responses in `#finish`, which results in invalid headers in the case of
empty responses. These will trigger `Rack::Lint` errors as well.

This modifies the definition of `Hobbit::Response#finish` to skip setting
the `Content-Length` header in the case of 1xx or 204 response codes.
