### PR TITLE
fix incomplete handling of no-content responses (100..199, 204, 205, 304)

### DIFF
--- a/lib/hobbit/response.rb
+++ b/lib/hobbit/response.rb
@@ -20,8 +20,10 @@ module Hobbit
       end
     end
 
-    def finish
-      unless (100..199).include?(status) || status == 204
+    def finish      
+      if status == 204 || status == 205 || status == 304 || (100..199).include?(status)
+        headers.delete 'Content-Type'
+      else
         headers['Content-Length'] = @length.to_s
       end
       [status, headers, body]


### PR DESCRIPTION
Neither Content-Type nor Content-Length should be present.

This is not mandatory according to the HTTP spec, however, Rack::Lint considers responses with the above status codes that contain either header as invalid.

Also, 205 and 304 response codes were not handled.