### PR TITLE
Decode extra parameters when processing route

### DIFF
--- a/lib/hobbit/base.rb
+++ b/lib/hobbit/base.rb
@@ -1,4 +1,5 @@
 require 'forwardable'
+require 'uri'
 
 module Hobbit
   class Base
@@ -83,7 +84,7 @@ module Hobbit
       if route
         $~.captures.each_with_index do |value, index|
           param = route[:extra_params][index]
-          request.params[param] = value
+          request.params[param] = URI.decode_www_form_component(value)
         end
       end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 
 scope Hobbit::Base do
   setup do
@@ -203,6 +203,14 @@ scope Hobbit::Base do
           send verb.downcase, '/not/found'
           assert last_response.not_found?
           assert_equal '', last_response.body
+        end
+      end
+
+      scope 'extracting extra parameters from URI' do
+        test 'it unescapes URI-encoded extra parameters' do
+          send verb.downcase, '/escaped%20value'
+          assert last_response.ok?
+          assert_equal 'escaped value', last_response.body
         end
       end
     end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 
 scope Hobbit::Request do
   scope '#initialize' do

--- a/test/response_test.rb
+++ b/test/response_test.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 
 scope Hobbit::Response do
   scope '#initialize' do

--- a/test/version_test.rb
+++ b/test/version_test.rb
@@ -1,4 +1,4 @@
-require 'helper'
+require_relative 'helper'
 
 scope Hobbit::VERSION do
   test "it's defined" do


### PR DESCRIPTION
Updates `Hobbit::Base#find_route` to perform URI-decoding on any dynamic
URI components before storing them in `request.params`. This provides
greater consistency with both Rack's existing query params parsing
and with other server libraries like Sinatra (which similarly decode
dynamic URI segments).

This ensures that everything in `request.params` (both from Rack and from Hobbit) will be URI-decoded, rather than mixing decoded query params and encoded path captures.

For comparison:

Rack (query param decoding): https://github.com/rack/rack/blob/8d2e02abba44ac7e9d0ed2a4af9beb6063a81296/lib/rack/utils.rb#L54

Sinatra (unescaping captures like this pull request):
https://github.com/sinatra/sinatra/blob/a9649b4f18a9059de3161906c9c6e95ec06fdef9/lib/sinatra/base.rb#L1053


I added a test and confirmed tests pass (although some of the other development dependencies, such as the Code Climate integration, seem to now be defunct)

Note that this *might* result in backwards-incompatibility if someone was dependent on the previous behavior. However, I believe this arrangement is more consistent.