### PR TITLE
Update development dependencies

### DIFF
--- a/hobbit.gemspec
+++ b/hobbit.gemspec
@@ -18,8 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'codeclimate-test-reporter'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'oktobertest'
   spec.add_development_dependency 'oktobertest-contrib'
   spec.add_development_dependency 'rack-test'

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,4 @@
 require 'bundler/setup'
-
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 require 'oktobertest'
 require 'oktobertest/contrib'
 require 'rack'


### PR DESCRIPTION
A couple of updates for development dependencies:

- Unlocks `bundler` from v1.x.x. I don't see any reason this requires
  Bundler 1, and Bundler 2 has been available for a while now.
- Removes a defunct codeclimate integration. This integration is no
  longer functioning and will crash the test suite. (It may be worth
  fixing the integration, but for now this will remove non-functioning
  code that actively causes problems when running tests).